### PR TITLE
Restore cleaning kit threshold, lower repair kit +% in vanilla crafti…

### DIFF
--- a/gamedata/configs/mod_system_zzzzzzzz_tgr_cleaning_kits.ltx
+++ b/gamedata/configs/mod_system_zzzzzzzz_tgr_cleaning_kits.ltx
@@ -3,23 +3,27 @@
 ; I hate the z-stack but blame GAMMA Guns Have No Condition.
 
 ![cleaning_kit_p]
-repair_min_condition 	                           = 0.20
 repair_add_condition 	                           = 0.15
-repair_only = barrel_a, gas_tube_a, trigger_components_a, spring_a, bolt_carrier_a, bolt_a, gas_tube_a
 
 ![cleaning_kit_s]
-repair_min_condition 	                           = 0.20
 repair_add_condition 	                           = 0.15
-repair_only = barrel_b, gas_tube_b, trigger_components_b, spring_b, bolt_carrier_b, bolt_b, gas_tube_b
 
 ![cleaning_kit_r5]
-repair_min_condition 	                           = 0.20
 repair_add_condition 	                           = 0.15
-repair_only = barrel_c, gas_tube_c, trigger_components_c, spring_c, bolt_carrier_c, bolt_c, gas_tube_c
 
 ![cleaning_kit_r7]
-repair_min_condition 	                           = 0.20
 repair_add_condition 	                           = 0.15
-repair_only = barrel_d, gas_tube_d, trigger_components_d, spring_d, bolt_carrier_d, bolt_d, gas_tube_d
 
-; Consider remapping parts to kits in the future.
+![toolkit_p]
+repair_add_condition                               = 0.20
+
+![toolkit_s]
+repair_add_condition                               = 0.20
+
+![toolkit_r5]
+repair_add_condition                               = 0.20
+
+![toolkit_r7]
+repair_add_condition                               = 0.20
+
+; Consider changing repair threshold later.


### PR DESCRIPTION
…ng menu

Restore the 60% threshold for cleaning kits, reduce condition added by repair kits in the vanilla Anomaly interface from +100% to +20%