### PR TITLE
Fix vice and non vice maintain bug

### DIFF
--- a/gamedata/scripts/arti_jamming_repairs_patch.script
+++ b/gamedata/scripts/arti_jamming_repairs_patch.script
@@ -84,6 +84,17 @@ zzzz_arti_jamming_repairs.has_suitable_kit = function(obj)
 	return allow
 end
 
+function GetExactKit(obj, clean)
+	local repair_sec = SYS_GetParam(0, obj:section(), "repair_type") or "none"
+	local toolkit_sec = toolkit_map[repair_sec] or "none"
+
+	if clean then
+		return db.actor:object(toolkit_sec[1]) or nil
+	else
+		return db.actor:object(toolkit_sec[2]) or nil
+	end
+end
+
 --SERIOUS: Need to patch differently to stay compatible with SERIOUS Weapon Maintain Features. 
 --(I just mark these veer, so later I can produce the compatibility patch easier)
 OldInitMaintenanceMenu = zzzz_arti_jamming_repairs.init_maintenance_menu
@@ -93,8 +104,9 @@ zzzz_arti_jamming_repairs.init_maintenance_menu = function(obj)
 	local context_params = {}
 
 	local parts = item_parts.get_parts_con(obj)
-	local clean_kit = zzzz_arti_jamming_repairs.get_suitable_kit(obj, true)
-	local repair_kit = zzzz_arti_jamming_repairs.get_suitable_kit(obj, false)
+	local clean_kit = GetExactKit(obj, true)
+	local repair_kit = GetExactKit(obj, false)
+
 	for k,v in pairs(parts) do
 		if is_part(k) then
 			if tgrUtils.CheckRepairThreshold(v) and v < tgrCfg.Get("cleaning_threshold", "cleaning_kit_p") and repair_kit then

--- a/gamedata/scripts/ui_workshop_patch.script
+++ b/gamedata/scripts/ui_workshop_patch.script
@@ -102,7 +102,6 @@ ui_workshop.UIWorkshopRepair.ListSpareParts = function (self)
 
 			utils_xml.set_icon(repairInfo.objWithLeastUses:section(), false, self.itm_ico_temp_rq, self.itm_ico_rq)
 		end
-
 		if maintenanceAmount > 0 then
 			for i=1,6 do
 				local shouldUpdate = not self.new_con or not self.new_con[i]
@@ -160,20 +159,38 @@ ui_workshop.UIWorkshopRepair.On_CC_Mouse1 = function (self, cont, idx)
 		if IsWeapon(obj) then
 			self.btn_maintain:Show(true)
 			
-			--Enable the clicking of the item parts if the player has at least 1 cleaning kit.
-			if self.maintenanceItems.repairing.compoundedUses <= 0 and self.maintenanceItems.cleaning.compoundedUses >= 1 then
-				utils_xml.set_icon(self.maintenanceItems.cleaning.objWithLeastUses:section(), false, self.itm_ico_temp_rq, self.itm_ico_rq)
+			--Enable the clicking of the item parts if the player has at least 1 cleaning or repair kit.
+			local hasAtLeastOneRep = self.maintenanceItems.repairing.compoundedUses >= 1
+			local hasAtLeastOneClean = self.maintenanceItems.cleaning.compoundedUses >= 1
+			local iconSection = (hasAtLeastOneRep and self.maintenanceItems.repairing.objWithLeastUses:section())
+								or (hasAtLeastOneClean and self.maintenanceItems.cleaning.objWithLeastUses:section())
+								or nil
+
+			if hasAtLeastOneRep or hasAtLeastOneClean then
+				utils_xml.set_icon(iconSection, false, self.itm_ico_temp_rq, self.itm_ico_rq)
 				self.itm_num_rq:SetText(clr_list["g"] .. tostring(self.maintenanceItems.cleaning.compoundedUses))
 
 				for i=1,6 do
 					local part = self.parts[i]
 					local con = 0
 
+					--Enables and shows non-greyed out icons for part scheme parts if conditions are met.
 					if part and part.con then
 						con = utils_item.get_cond_static(part.con)
-						if tgrUtils.CheckCleanThreshold(con) then
+						if (hasAtLeastOneRep and tgrUtils.CheckRepairThreshold(con))
+						or (hasAtLeastOneClean and tgrUtils.CheckCleanThreshold(con)) then
+
+							utils_xml.set_icon(self.parts[i].sec, false, self.itm_ico_temp[i], self.itm_ico[i])
 							self.itm_btn[i]:Show(true)
 						end
+					end
+				end
+			else
+				for i=1,6 do
+					local part = self.parts[i]
+					if part and part.con then
+						utils_xml.set_icon(self.parts[i].sec, true, self.itm_ico_temp[i], self.itm_ico[i])
+						self.itm_btn[i]:Show(false)
 					end
 				end
 			end


### PR DESCRIPTION
Fixes #27 
Also fixes gun part highlighting now it properly reflects interactibility.
Fixes non-vice maintenance context menu allowing using repair kits as cleaning kits.