### PR TITLE
Economy changes

### DIFF
--- a/gamedata/configs/items/settings/mod_craft_tgr_kits.ltx
+++ b/gamedata/configs/items/settings/mod_craft_tgr_kits.ltx
@@ -1,0 +1,13 @@
+![3]
+
+; Cleaning kits
+x_cleaning_kit_p  = 1, recipe_basic_0,    gun_oil,      3, swiss_knife, 1, grooming, 2, steel_wool, 1
+x_cleaning_kit_s  = 1, recipe_basic_0,    gun_oil_ru_d, 3, rasp_tool,   1, grooming, 2, steel_wool, 2
+x_cleaning_kit_r5 = 2, recipe_advanced_0, gun_oil_ru,   3, rasp_tool,   2, grease,   1, steel_wool, 2
+x_cleaning_kit_r7 = 2, recipe_advanced_0, solvent,      3, rasp_tool,   2, grease,   2, steel_wool, 4
+
+; Repair kits
+x_toolkit_p       = 1, recipe_basic_0,    cleaning_kit_p,  4, gun_oil,      3, ramrod_tool,     2, steel_wool, 1
+x_toolkit_s       = 1, recipe_basic_0,    cleaning_kit_s,  4, gun_oil_ru_d, 3, ramrod_tool,     4, steel_wool, 2
+x_toolkit_r5      = 2, recipe_advanced_0, cleaning_kit_r5, 4, gun_oil_ru,   4, leatherman_tool, 2, steel_wool, 4
+x_toolkit_r7      = 3, recipe_expert_0,   cleaning_kit_r7, 4, solvent,      6, leatherman_tool, 3, steel_wool, 4

--- a/gamedata/configs/items/trade/mod_trade_bandit_basic_tgr.ltx
+++ b/gamedata/configs/items/trade/mod_trade_bandit_basic_tgr.ltx
@@ -1,0 +1,2 @@
+; Reduce buy price for cleaning and repair kits
+#include "presets\trade_presets_tgr.ltx"

--- a/gamedata/configs/items/trade/mod_trade_bandit_tgr.ltx
+++ b/gamedata/configs/items/trade/mod_trade_bandit_tgr.ltx
@@ -1,0 +1,2 @@
+; Reduce buy price for cleaning and repair kits
+#include "presets\trade_presets_tgr.ltx"

--- a/gamedata/configs/items/trade/mod_trade_csky_spore_tgr.ltx
+++ b/gamedata/configs/items/trade/mod_trade_csky_spore_tgr.ltx
@@ -1,0 +1,2 @@
+; Reduce buy price for cleaning and repair kits
+#include "presets\trade_presets_tgr.ltx"

--- a/gamedata/configs/items/trade/mod_trade_duty_tgr.ltx
+++ b/gamedata/configs/items/trade/mod_trade_duty_tgr.ltx
@@ -1,0 +1,2 @@
+; Reduce buy price for cleaning and repair kits
+#include "presets\trade_presets_tgr.ltx"

--- a/gamedata/configs/items/trade/mod_trade_freedom_ashot_tgr.ltx
+++ b/gamedata/configs/items/trade/mod_trade_freedom_ashot_tgr.ltx
@@ -1,0 +1,2 @@
+; Reduce buy price for cleaning and repair kits
+#include "presets\trade_presets_tgr.ltx"

--- a/gamedata/configs/items/trade/mod_trade_freedom_tgr.ltx
+++ b/gamedata/configs/items/trade/mod_trade_freedom_tgr.ltx
@@ -1,0 +1,2 @@
+; Reduce buy price for cleaning and repair kits
+#include "presets\trade_presets_tgr.ltx"

--- a/gamedata/configs/items/trade/mod_trade_generic_mechanic_tgr.ltx
+++ b/gamedata/configs/items/trade/mod_trade_generic_mechanic_tgr.ltx
@@ -1,3 +1,6 @@
+; Reduce buy price for cleaning and repair kits
+#include "presets\trade_presets_tgr.ltx"
+
 ![supplies_1]  ; -- No tools
 ; remove cleaning kits aside from cleaning_kit_p and _s
 !cleaning_kit_r5         = 1, 1

--- a/gamedata/configs/items/trade/mod_trade_generic_mechanic_tgr.ltx
+++ b/gamedata/configs/items/trade/mod_trade_generic_mechanic_tgr.ltx
@@ -6,20 +6,87 @@
 !cleaning_kit_r5         = 1, 1
 !cleaning_kit_r7         = 1, 1
 
-; future: increase amount of cleaning kit components for sale?
+; Crafting supplies changes
+gun_oil                 = 2, 1
+gun_oil_ru_d            = 2, 1
+gun_oil_ru              = 2, 1
+solvent                 = 1, 1
+
+swiss_knife             = 3, 1
+ball_hammer             = 2, 1
+duct_tape               = 4, 1
+grease                  = 1, 1
+
+grooming                = 2, 1
+leatherman_tool         = 1, 1
+rasp_tool               = 2, 1
+ramrod_tool             = 2, 1 
+steel_wool              = 4, 1 
+
 
 ![supplies_2]  ; -- Basic tools
 cleaning_kit_r5         = 1, 1
 !cleaning_kit_r7        = 2, 1
 
-![supplies_3]  ; -- Advanced tools given
+; Crafting supplies changes
+gun_oil                 = 2, 1
+gun_oil_ru_d            = 2, 1
+gun_oil_ru              = 2, 1
+solvent                 = 2, 1
+
+swiss_knife             = 5, 1
+ball_hammer             = 4, 1
+duct_tape               = 6, 1
+grease                  = 1, 1
+
+grooming                = 2, 1
+leatherman_tool         = 1, 1
+rasp_tool               = 3, 1
+ramrod_tool             = 3, 1 
+steel_wool              = 6, 1 
+
+![supplies_3]  ; -- Advanced tools
 cleaning_kit_p          = 2, 1
 cleaning_kit_s          = 2, 1
 cleaning_kit_r5         = 2, 1
 cleaning_kit_r7         = 1, 1
+
+; Crafting supplies changes
+gun_oil                 = 3, 1
+gun_oil_ru_d            = 3, 1
+gun_oil_ru              = 3, 1
+solvent                 = 3, 1
+
+swiss_knife             = 6, 1
+ball_hammer             = 8, 1
+duct_tape               = 8, 1
+grease                  = 2, 1
+
+grooming                = 3, 1
+leatherman_tool         = 1, 1
+rasp_tool               = 3, 1
+ramrod_tool             = 3, 1 
+steel_wool              = 8, 1 
 
 ![supplies_4]  ; -- Expert tools given
 cleaning_kit_p          = 3, 1
 cleaning_kit_s          = 3, 1
 cleaning_kit_r5         = 2, 1
 cleaning_kit_r7         = 2, 1
+
+; Crafting supplies changes
+gun_oil                 = 6, 1
+gun_oil_ru_d            = 6, 1
+gun_oil_ru              = 4, 1
+solvent                 = 4, 1
+
+swiss_knife             = 6, 1
+ball_hammer             = 10, 1
+duct_tape               = 12, 1
+grease                  = 3, 1
+
+grooming                = 4, 1
+leatherman_tool         = 2, 1
+rasp_tool               = 5, 1
+ramrod_tool             = 5, 1 
+steel_wool              = 12, 1 

--- a/gamedata/configs/items/trade/mod_trade_greh_tgr.ltx
+++ b/gamedata/configs/items/trade/mod_trade_greh_tgr.ltx
@@ -1,0 +1,2 @@
+; Reduce buy price for cleaning and repair kits
+#include "presets\trade_presets_tgr.ltx"

--- a/gamedata/configs/items/trade/mod_trade_isg_light_tgr.ltx
+++ b/gamedata/configs/items/trade/mod_trade_isg_light_tgr.ltx
@@ -1,0 +1,2 @@
+; Reduce buy price for cleaning and repair kits
+#include "presets\trade_presets_tgr.ltx"

--- a/gamedata/configs/items/trade/mod_trade_isg_mission_tgr.ltx
+++ b/gamedata/configs/items/trade/mod_trade_isg_mission_tgr.ltx
@@ -1,0 +1,2 @@
+; Reduce buy price for cleaning and repair kits
+#include "presets\trade_presets_tgr.ltx"

--- a/gamedata/configs/items/trade/mod_trade_isg_tgr.ltx
+++ b/gamedata/configs/items/trade/mod_trade_isg_tgr.ltx
@@ -1,0 +1,2 @@
+; Reduce buy price for cleaning and repair kits
+#include "presets\trade_presets_tgr.ltx"

--- a/gamedata/configs/items/trade/mod_trade_mercenary_basic_tgr.ltx
+++ b/gamedata/configs/items/trade/mod_trade_mercenary_basic_tgr.ltx
@@ -1,0 +1,2 @@
+; Reduce buy price for cleaning and repair kits
+#include "presets\trade_presets_tgr.ltx"

--- a/gamedata/configs/items/trade/mod_trade_mercenary_meeker_tgr.ltx
+++ b/gamedata/configs/items/trade/mod_trade_mercenary_meeker_tgr.ltx
@@ -1,0 +1,2 @@
+; Reduce buy price for cleaning and repair kits
+#include "presets\trade_presets_tgr.ltx"

--- a/gamedata/configs/items/trade/mod_trade_mercenary_tgr.ltx
+++ b/gamedata/configs/items/trade/mod_trade_mercenary_tgr.ltx
@@ -1,0 +1,2 @@
+; Reduce buy price for cleaning and repair kits
+#include "presets\trade_presets_tgr.ltx"

--- a/gamedata/configs/items/trade/mod_trade_military_esc_tgr.ltx
+++ b/gamedata/configs/items/trade/mod_trade_military_esc_tgr.ltx
@@ -1,0 +1,2 @@
+; Reduce buy price for cleaning and repair kits
+#include "presets\trade_presets_tgr.ltx"

--- a/gamedata/configs/items/trade/mod_trade_military_tgr.ltx
+++ b/gamedata/configs/items/trade/mod_trade_military_tgr.ltx
@@ -1,0 +1,2 @@
+; Reduce buy price for cleaning and repair kits
+#include "presets\trade_presets_tgr.ltx"

--- a/gamedata/configs/items/trade/mod_trade_monolith_basic_tgr.ltx
+++ b/gamedata/configs/items/trade/mod_trade_monolith_basic_tgr.ltx
@@ -1,0 +1,2 @@
+; Reduce buy price for cleaning and repair kits
+#include "presets\trade_presets_tgr.ltx"

--- a/gamedata/configs/items/trade/mod_trade_monolith_tgr.ltx
+++ b/gamedata/configs/items/trade/mod_trade_monolith_tgr.ltx
@@ -1,0 +1,2 @@
+; Reduce buy price for cleaning and repair kits
+#include "presets\trade_presets_tgr.ltx"

--- a/gamedata/configs/items/trade/mod_trade_renegade_tgr.ltx
+++ b/gamedata/configs/items/trade/mod_trade_renegade_tgr.ltx
@@ -1,0 +1,2 @@
+; Reduce buy price for cleaning and repair kits
+#include "presets\trade_presets_tgr.ltx"

--- a/gamedata/configs/items/trade/mod_trade_stalker_basic_tgr.ltx
+++ b/gamedata/configs/items/trade/mod_trade_stalker_basic_tgr.ltx
@@ -1,0 +1,2 @@
+; Reduce buy price for cleaning and repair kits
+#include "presets\trade_presets_tgr.ltx"

--- a/gamedata/configs/items/trade/mod_trade_stalker_butcher_tgr.ltx
+++ b/gamedata/configs/items/trade/mod_trade_stalker_butcher_tgr.ltx
@@ -1,0 +1,2 @@
+; Reduce buy price for cleaning and repair kits
+#include "presets\trade_presets_tgr.ltx"

--- a/gamedata/configs/items/trade/mod_trade_stalker_flea_market_night_tgr.ltx
+++ b/gamedata/configs/items/trade/mod_trade_stalker_flea_market_night_tgr.ltx
@@ -1,0 +1,2 @@
+; Reduce buy price for cleaning and repair kits
+#include "presets\trade_presets_tgr.ltx"

--- a/gamedata/configs/items/trade/mod_trade_stalker_flea_market_tgr.ltx
+++ b/gamedata/configs/items/trade/mod_trade_stalker_flea_market_tgr.ltx
@@ -1,0 +1,2 @@
+; Reduce buy price for cleaning and repair kits
+#include "presets\trade_presets_tgr.ltx"

--- a/gamedata/configs/items/trade/mod_trade_stalker_loris_tgr.ltx
+++ b/gamedata/configs/items/trade/mod_trade_stalker_loris_tgr.ltx
@@ -1,0 +1,2 @@
+; Reduce buy price for cleaning and repair kits
+#include "presets\trade_presets_tgr.ltx"

--- a/gamedata/configs/items/trade/mod_trade_stalker_nimble_tgr.ltx
+++ b/gamedata/configs/items/trade/mod_trade_stalker_nimble_tgr.ltx
@@ -1,0 +1,2 @@
+; Reduce buy price for cleaning and repair kits
+#include "presets\trade_presets_tgr.ltx"

--- a/gamedata/configs/items/trade/mod_trade_stalker_owl_tgr.ltx
+++ b/gamedata/configs/items/trade/mod_trade_stalker_owl_tgr.ltx
@@ -1,0 +1,2 @@
+; Reduce buy price for cleaning and repair kits
+#include "presets\trade_presets_tgr.ltx"

--- a/gamedata/configs/items/trade/mod_trade_stalker_sidorovich_tgr.ltx
+++ b/gamedata/configs/items/trade/mod_trade_stalker_sidorovich_tgr.ltx
@@ -1,0 +1,2 @@
+; Reduce buy price for cleaning and repair kits
+#include "presets\trade_presets_tgr.ltx"

--- a/gamedata/configs/items/trade/presets/trade_presets_tgr.ltx
+++ b/gamedata/configs/items/trade/presets/trade_presets_tgr.ltx
@@ -1,0 +1,19 @@
+;Make selling repair and cleaning kits unprofitable (traders buy for 20% of price)
+![repair_kits_tgr]
+cleaning_kit_p	= 0.2
+cleaning_kit_s	= 0.2
+cleaning_kit_r5	= 0.2
+cleaning_kit_r7	= 0.2
+toolkit_p		= 0.2
+toolkit_s		= 0.2
+toolkit_r5		= 0.2
+toolkit_r7		= 0.2
+
+; Add the new section to the traders that buy repair kits
+![supplier]:repair_kits_tgr
+
+![merchant]:repair_kits_tgr
+
+![trasher]:repair_kits_tgr
+
+![mechanic]:repair_kits_tgr

--- a/gamedata/configs/mod_system_zzzzzzzz_tgr_cleaning_kits.ltx
+++ b/gamedata/configs/mod_system_zzzzzzzz_tgr_cleaning_kits.ltx
@@ -4,31 +4,39 @@
 
 ![cleaning_kit_p]:clean_vice_bonus
 repair_add_condition 	                            = 0.15
+cost                                                = 4730
 
 ![cleaning_kit_s]:clean_vice_bonus
 repair_add_condition 	                            = 0.15
+cost                                                = 5930
 
 ![cleaning_kit_r5]:clean_vice_bonus
 repair_add_condition 	                            = 0.15
+cost                                                = 7542
 
 ![cleaning_kit_r7]:clean_vice_bonus
 repair_add_condition 	                            = 0.15
+cost                                                = 9845
 
 ![toolkit_p]:repair_vice_bonus
 repair_max_condition                                = 0.60
 repair_add_condition                                = 0.20
+cost                                                = 17056
 
 ![toolkit_s]:repair_vice_bonus
 repair_max_condition                                = 0.60
 repair_add_condition                                = 0.20
+cost                                                = 30990
 
 ![toolkit_r5]:repair_vice_bonus
 repair_max_condition                                = 0.60
 repair_add_condition                                = 0.20
+cost                                                = 43214
 
 ![toolkit_r7]:repair_vice_bonus
 repair_max_condition                                = 0.60
 repair_add_condition                                = 0.20
+cost                                                = 54144
 
 [clean_vice_bonus]
 vice_bonus                                          = 0.10


### PR DESCRIPTION
- Increases the cost of all repair/crafting kits, by +20% - +80% of previous costs
- Makes all vendors buy repair/crafting kits at a flat 20% of their cost, so you can never turn a profit selling them
- Changes crafting/repair kit crafting recipes for smoother, more consistent input item progression, as well as slightly increasing crafting costs
- Mechanics' inventory of crafting inputs drastically reduced
    - This is balanced around allowing players to make *one* cleaning or repair kit, after *one* trip to a lvl 3 mechanic (though type D kits will almost always require multiple trips to mechanics to buy all inputs)
    - I did try to take into account the crafting costs of other items like hunting kits and weapon upgrade kits as well
    - Mechanics start with far fewer crafting inputs, to encourage upgrading multiple mechanics' supply levels